### PR TITLE
devtest: force clib2 slab allocator on KS2.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,7 @@ CFLAGS  := -Wall -Wextra -Wno-pointer-sign -fomit-frame-pointer
 CFLAGS  += -Wno-strict-aliasing
 CFLAGS  += -Wpedantic -Wno-overflow
 
-# clib2 crashes on exit under Kickstart 2.x
 LDFLAGS := -Xlinker -Map=$(OBJDIR)/$@.map -Wa,-a > $(OBJDIR)/$@.lst -fomit-frame-pointer -lgcc -lc -lamiga -mcrt=clib2
-
-# -noixemul generates significantly larger binaries, but KS 2.x is supported
-#LDFLAGS := -Xlinker -Map=$(OBJDIR)/$@.map -Wa,-a > $(OBJDIR)/$@.lst -fomit-frame-pointer -lgcc -lc -lamiga -noixemul
 
 #CFLAGS += -flto
 #LDFLAGS += -flto

--- a/devtest.c
+++ b/devtest.c
@@ -284,6 +284,12 @@ static void report_allocmem_fail(uint bufsize, uint memtype);
 #define IBUF_COUNT    6   // Integrity test buffers
 
 BOOL __check_abort_enabled = 0;       // Disable gcc clib2 ^C break handling
+/*
+ * KS2.x lacks Exec memory pools, so clib2 otherwise tracks malloc chunks
+ * with its own Exec list.  Force the slab allocator; BUFSIZE is 8192, so
+ * keep this larger than standard I/O buffers.
+ */
+unsigned long __slab_max_size = 16384;
 
 static int       g_verbose = 0;       // Verbose output
 static int       g_changenum = 0;     // Current device media change number


### PR DESCRIPTION
Define __slab_max_size to 16 KiB so clib2 initializes its slab allocator
for small allocations. This keeps standard I/O buffers, which are 8 KiB,
on the slab path.

Kickstart 2.x lacks Exec memory pools, so clib2 otherwise falls back to
tracking malloc chunks with an Exec list. The observed exit crash
happens during stdio cleanup and the faulting PC matches Exec Remove()
on that list, so avoid that allocator path on KS2.x.
